### PR TITLE
[MISC] Add workflow to update github page with API docs

### DIFF
--- a/.github/workflows/github-page-build-and-deploy.yml
+++ b/.github/workflows/github-page-build-and-deploy.yml
@@ -1,0 +1,49 @@
+name: Build and Deploy GithubPage
+# See https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan for details on Deploy step
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  PublishGithubPage:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '3.6'
+          architecture: x64
+
+      - name: Init Template
+        env:
+          python_version: '3.6'
+        run: echo -e "${python_version}\nTEMPLATE\nsrc\nBasic Template\nn" | bash bin/init_repo.sh
+
+      - name: Compile Requirements
+        run: make reqs
+
+      - name: Install
+        run: pip install -r requirements/requirements_ci.txt
+
+      - name: Generate content
+        run: make --directory=sphinx --file=Makefile html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/html
+          publish_branch: gh_pages
+          allow_empty_commit: false
+          enable_jekyll: false
+          force_orphan: false
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: "${{ github.ref_name }} - ${{ github.event.head_commit.message }}"
+

--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ We use ``mypy`` for static type checking. The configuration is included in ``set
 The only settings included in this configuration files are related to the missing typing annotations of some common third party libraries.
 
 ### Documentation
-This project uses `Sphinx` (https://www.sphinx-doc.org/en/master/) as a tool to create documentation. Run `make docs` to build documentation 
+This project uses `Sphinx` (https://www.sphinx-doc.org/en/master/) as a tool to create documentation. Run `make docs` to build documentation.
+There is a github workflow setup to publish documentation on the repo's Github Page at every push on `main` branch. 
+To let this action run smoothly there must exist the `gh_pages`branch and the Github Page must be manually setted (from
+github repo web interface > Settings > Pages) to use `gh_pages` as source branch and `/root` as source folder. 
+Since this action requires a GITHUB_TOKEN, for its first run in the repo it will be necessary to follow the steps 
+detailed [here]( https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token) 
+to make the action run fine from then on.
 
 ### Semantic Versioning
 

--- a/bin/init_repo.sh
+++ b/bin/init_repo.sh
@@ -31,6 +31,7 @@ templates=(
     "templates/${PYTHON_VERSION}/requirements_ci.in:requirements/requirements_ci.in"
     "templates/continous-delivery.yml.tmpl:.github/workflows/continous-delivery.yml"
     "templates/continous-integration.yml.tmpl:.github/workflows/continous-integration.yml"
+    "templates/github-page-build-and-deploy.yml.tmpl:.github/workflows/github-page-build-and-deploy.yml"
     "templates/Dockerfile.tmpl:Dockerfile"
     "templates/Makefile.tmpl:Makefile"
     "templates/MANIFEST.in.tmpl:MANIFEST.in"

--- a/templates/github-page-build-and-deploy.yml.tmpl
+++ b/templates/github-page-build-and-deploy.yml.tmpl
@@ -1,0 +1,44 @@
+name: Build and Deploy GithubPage
+# See https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan for details on Deploy step
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  PublishGithubPage:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '{{PYTHON_VERSION}}'
+          architecture: x64
+
+      - name: Compile Requirements
+        run: make reqs
+
+      - name: Install
+        run: pip install -r requirements/requirements_ci.txt
+
+      - name: Generate content
+        run: make --directory=sphinx --file=Makefile html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/html
+          publish_branch: gh_pages
+          allow_empty_commit: false
+          enable_jekyll: false
+          force_orphan: false
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: "${{ github.ref_name }} - ${{ github.event.head_commit.message }}"
+


### PR DESCRIPTION
This PR closes issue #37

This solution is inspired by [this repo](https://github.com/rayluo/github-pages-overwriter) and is based on the following version Control System philosophy:

1. The repo stores the history of your project's source code and assets.
2. Any artefact that can be built from a snapshot of those source code and assets,
   should **not** be stored inside the repo history.

Yet, in order to take advantage of the free hosting service of Github Pages, those artefacts would need to be stored inside a repo, thus violating tenet 2 above.
Some publisher actions work around this by pushing the artefacts into a dummy repo which is only used for hosting the static website.
That's fine, but one'd need to provide a personal access token (PAT) for it, and then configure the Github Action to use the it.

This workflow takes a simpler approach. The artefact will be forcefully pushed into the `gh-pages` branch (overwriting it)
inside the same main repo. This way, that publish commit would be overwritten each time and won't become part of the repo's long term history.

1. For example, the repo starts like this when one is ready for the first publish:

   ```
    D---E---F  main
   ```

2. After triggering this action once, the repo would look like:

   ```
              A  gh-pages
             /
    D---E---F  main
   ```

3. Later one adds more work into the repo, and is ready for a new publish.

   ```
              A  gh-pages
             /
    D---E---F---G---H  main
   ```

4. Triggering this action one more time, the repo would look like this:

   ```
                      A'  gh-pages
                     /
    D---E---F---G---H  main
   ```
