### PR TITLE
[MISC] Fix CD workflow

### DIFF
--- a/.github/workflows/github-page-build-and-deploy.yml
+++ b/.github/workflows/github-page-build-and-deploy.yml
@@ -25,14 +25,8 @@ jobs:
           python_version: '3.6'
         run: echo -e "${python_version}\nTEMPLATE\nsrc\nBasic Template\nn" | bash bin/init_repo.sh
 
-      - name: Compile Requirements
-        run: make reqs
-
-      - name: Install
-        run: pip install -r requirements/requirements_ci.txt
-
       - name: Generate content
-        run: make --directory=sphinx --file=Makefile html
+        run: make docs
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/bin/init_repo.sh
+++ b/bin/init_repo.sh
@@ -31,6 +31,8 @@ templates=(
     "templates/${PYTHON_VERSION}/requirements_ci.in:requirements/requirements_ci.in"
     "templates/continous-delivery.yml.tmpl:.github/workflows/continous-delivery.yml"
     "templates/continous-integration.yml.tmpl:.github/workflows/continous-integration.yml"
+    "templates/PyPI-release.yml.tmpl:.github/workflows/PyPI-release.yml"
+    "templates/TestPyPI-release.yml.tmpl:.github/workflows/TestPyPI-release.yml"
     "templates/github-page-build-and-deploy.yml.tmpl:.github/workflows/github-page-build-and-deploy.yml"
     "templates/source_index.rst.tmpl:sphinx/source/index.rst"
     "templates/userguide_index.rst.tmpl:sphinx/source/userguide/index.rst"

--- a/templates/3.6/requirements_ci.in
+++ b/templates/3.6/requirements_ci.in
@@ -13,3 +13,4 @@ recommonmark>=0.7
 sphinx-rtd-theme>=0.5
 types-dataclasses>=0.6.4
 versioneer>=0.21
+twine>=3.8

--- a/templates/3.7/requirements_ci.in
+++ b/templates/3.7/requirements_ci.in
@@ -12,3 +12,4 @@ pytest>=6.2
 recommonmark>=0.7
 sphinx-rtd-theme>=0.5
 versioneer>=0.21
+twine>=3.8

--- a/templates/3.8/requirements_ci.in
+++ b/templates/3.8/requirements_ci.in
@@ -12,3 +12,4 @@ pytest>=6.2
 recommonmark>=0.7
 sphinx-rtd-theme>=0.5
 versioneer>=0.21
+twine>=3.8

--- a/templates/3.9/requirements_ci.in
+++ b/templates/3.9/requirements_ci.in
@@ -12,3 +12,4 @@ pytest>=6.2
 recommonmark>=0.7
 sphinx-rtd-theme>=0.5
 versioneer>=0.21
+twine>=3.8

--- a/templates/Makefile.tmpl
+++ b/templates/Makefile.tmpl
@@ -53,7 +53,7 @@ $(pre_deps_tag):
 
 requirements/requirements.txt: requirements/requirements_ci.txt
 	cat requirements/requirements.in > subset.in
-	echo "-c requirements/requirements_ci.txt" >> subset.in
+	echo "\n-c requirements/requirements_ci.txt" >> subset.in
 	pip-compile --output-file "requirements/requirements.txt" --quiet --no-emit-index-url subset.in
 	rm subset.in
 
@@ -82,19 +82,19 @@ format: setup_ci
 	${PYTHON} -m black $(folders)
 
 dist/.build-tag: $(files) setup.cfg requirements/requirements.txt
-	python setup.py sdist
+	${PYTHON} setup.py sdist
 	ls -rt  dist/* | tail -1 > dist/.build-tag
 
 dist: dist/.build-tag setup.py
 
 $(install_tag): dist/.build-tag
-	${PYTHON} -m pip install $(shell ls -rt  dist/* | tail -1)
+	${PYTHON} -m pip install $(shell ls -rt  dist/*.tar.gz | tail -1)
 	touch $(install_tag)
 
 uninstall:
 	@echo "Uninstall package $(package_name)"
-	pip uninstall -y $(package_name)
-	pip freeze | grep -v "@" | xargs pip uninstall -y
+	${PYTHON} -m pip uninstall -y $(package_name)
+	${PYTHON} -m pip freeze | grep -v "@" | xargs pip uninstall -y
 	rm -f $(env_tag) $(env_ci_tag) $(pre_deps_tag) $(install_tag)
 
 install: setup $(install_tag)
@@ -116,5 +116,18 @@ docs: setup_ci $(install_tag) $(doc_files) setup.cfg
 
 clean: uninstall
 	rm -rf docs
+	rm -rf build
 	rm -rf $(shell find . -name "*.pyc") $(shell find . -name "__pycache__")
 	rm -rf dist *.egg-info .mypy_cache .pytest_cache .make_cache $(env_tag) $(env_ci_tag) $(install_tag)
+
+publish_test: setup_ci dist
+	${PYTHON} setup.py bdist_wheel; \
+    NAME=$$(${PYTHON} setup.py --fullname); \
+    if [[ $$NAME =~ .*"+".* || $$NAME == "" ]]; then echo "This is a temporary version:" $${NAME}; exit 1;\
+    else ${PYTHON} -m twine upload --repository testpypi dist/$${NAME}*; fi
+
+publish: setup_ci dist
+	${PYTHON} setup.py bdist_wheel; \
+    NAME=$$(${PYTHON} setup.py --fullname); \
+    if [[ "$${NAME}" =~ .*"+".* || "$${NAME}" == "" ]]; then echo "This is a temporary version: $${NAME}"; exit 1; \
+    else ${PYTHON} -m twine upload dist/$${NAME}*; fi

--- a/templates/PyPI-release.yml.tmpl
+++ b/templates/PyPI-release.yml.tmpl
@@ -1,0 +1,38 @@
+name: Release on PyPI
+
+defaults:
+  run:
+    shell: bash
+
+on: [workflow_dispatch]
+
+jobs:
+  autorelease:
+    name: Release on TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.3.4
+
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '{{PYTHON_VERSION}}'
+
+      - name: Check typing, linting, formatting and run unit-tests
+        run: make checks
+
+      - name: Build distribution and wheel
+        run: |
+          python -m pip install build wheel
+          python setup.py sdist bdist_wheel
+
+      - name: Add version to environment vars
+        run: |
+          NAME=$(python setup.py --fullname)
+          echo "NAME=$NAME" >> $GITHUB_ENV
+
+      - name: Publish distribution to PyPI
+        run: |
+          if [[ "${NAME}" =~ .*"+".* ]]; then echo "This is a temporary version: ${NAME}"; exit 1; fi
+          echo -e "__token__\n${{ secrets.PYPI_TOKEN }}" | ${PYTHON} -m twine upload dist/${NAME}*

--- a/templates/TestPyPI-release.yml.tmpl
+++ b/templates/TestPyPI-release.yml.tmpl
@@ -1,0 +1,38 @@
+name: Release on TestPyPI
+
+defaults:
+  run:
+    shell: bash
+
+on: [workflow_dispatch]
+
+jobs:
+  autorelease:
+    name: Release on TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.3.4
+
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '{{PYTHON_VERSION}}'
+
+      - name: Check typing, linting, formatting and run unit-tests
+        run: make checks
+
+      - name: Build distribution and wheel
+        run: |
+          python -m pip install build wheel
+          python setup.py sdist bdist_wheel
+
+      - name: Add version to environment vars
+        run: |
+          NAME=$(python setup.py --fullname)
+          echo "NAME=$NAME" >> $GITHUB_ENV
+
+      - name: Publish distribution to TestPyPI
+        run: |
+          if [[ "${NAME}" =~ .*"+".* ]]; then echo "This is a temporary version: ${NAME}"; exit 1; fi
+          echo -e "__token__\n${{ secrets.TESTPYPI_TOKEN }}" | ${PYTHON} -m twine upload --repository testpypi dist/${NAME}*

--- a/templates/continous-delivery.yml.tmpl
+++ b/templates/continous-delivery.yml.tmpl
@@ -1,10 +1,10 @@
-name: CI - Create a Release
+name: CD - Create a Release
 
-on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+on: [workflow_dispatch]
+#  push:
+#    # Sequence of patterns matched against refs/tags
+#    tags:
+#      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   autorelease:
@@ -19,6 +19,12 @@ jobs:
         with:
           python-version: '{{PYTHON_VERSION}}'
 
+      - name: Build source and binary distributions
+        shell: bash -l {0}
+        run: |
+          python -m pip install build wheel
+          python setup.py sdist bdist_wheel
+
       - name: Add version to environment vars
         run: |
           PROJECT_VERSION=$(python setup.py --version)
@@ -31,14 +37,38 @@ jobs:
           echo $PROJECT_VERSION
           if [[ "$TAG" != "v$PROJECT_VERSION" ]]; then exit 1; fi
 
-      - name: Check typing, linting, formatting and run unit-tests
-        run: make checks
-
-      - name: Build distributions
-        shell: bash -l {0}
+      - name: Check source package structure
         run: |
-          python -m pip install build wheel
-          python setup.py sdist bdist_wheel
+          tar -xzf $(ls -rt  dist/*.tar.gz | tail -1)
+          DIR=$(python setup.py --fullname)
+          rm -rf $(find . -name "*.pyc") $(find . -name "__pycache__")
+          files=(
+            "requirements/requirements.txt"
+            "LICENSE"
+            "MANIFEST.in"
+            "PKG-INFO"
+            "README.md"
+            "setup.cfg"
+            "setup.py"
+            "versioneer.py"
+          )
+          while IFS= read -d $'\0' -r file ; do
+            if [[ "${file}" =~ .*".py" ]]; then files=("${files[@]}" "$file"); fi;
+          done < <(find cgnal -print0)
+
+          for file in "${files[@]}" ; do
+            if [ ! -f "${DIR}/${file}" ]; then echo "Missing ${file}"; exit 1; fi
+          done
+
+          rm -rf $DIR
+
+      - name: Check typing, linting and formatting
+        run: |
+          python -m pip install -r requirements/requirements_ci.txt
+          python -m black {{SRC}} tests
+          flake8 {{SRC}} tests
+          mypy --install-types --non-interactive --follow-imports silent {{SRC}} tests
+          python -m pytest
 
       - name: Release Notes
         uses: heinrichreimer/github-changelog-generator-action@v2.3
@@ -46,21 +76,33 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: ".github/RELEASE-TEMPLATE.md"
 
-      - name: Create Release
+      - name: Create Github Release
         uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body_path: ".github/RELEASE-TEMPLATE.md"
           files: |
-            dist/{{PROJECT_NAME}}-${{env.PROJECT_VERSION}}-py3-none-any.whl
-            dist/{{PROJECT_NAME}}-${{env.PROJECT_VERSION}}.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            dist/cgnal-core-${{env.PROJECT_VERSION}}-py3-none-any.whl
+            dist/cgnal-core-${{env.PROJECT_VERSION}}.tar.gz
 
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.TESTPYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+
+      - name: Test distribution published on Test PyPI
+        run: |
+          mkdir pkgs
+          make uninstall
+          sleep 5m
+          python -m pip download --index-url https://test.pypi.org/simple/ --no-deps --dest pkgs {{PROJECT_NAME}}==${{env.PROJECT_VERSION}}
+          python -m pip install $(ls -rt  pkgs/* | tail -1)
+          python -m pip install pytest pytest-cov mongomock
+          python -m pytest
+          rm -rf pkgs
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Here it is my proposal to close #46, implementing both `make` commands and manually-only workflows.
Basically the different between the two solutions is that the make command should require to manually add the API token while the action allows to store the tokens using github secrets.

I could not completely test these processes, so please revise them as accurately as possible